### PR TITLE
Check if opened before calling close

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -269,9 +269,14 @@ export default function (Alpine) {
     };
 
     panel.close = function () {
+      if (! panel._x_isShown) {
+        return false;
+      }
+      
       // if (typeof panel._x_toggleAndCascadeWithTransitions === "function") {
       //   panel._x_toggleAndCascadeWithTransitions(panel, false, show, hide);
       // }
+      
       toggle(false);
 
       panel.trigger.setAttribute("aria-expanded", false);


### PR DESCRIPTION
Ensure the floating UI is open before calling close. 

Fixes error:
> can't access property "setAttribute", i.trigger is null